### PR TITLE
Untracked File Support

### DIFF
--- a/markout-markdown/src/test/kotlin/FilePathTests.kt
+++ b/markout-markdown/src/test/kotlin/FilePathTests.kt
@@ -12,8 +12,10 @@ class FilePathTests {
             out.inline(name)
             out.newline()
 
-            if (entry is OutputDirectory) {
-                extractPaths(entry, out.prefixed("$name/"))
+            val output = entry.output
+
+            if (output is OutputDirectory) {
+                extractPaths(output, out.prefixed("$name/"))
             }
         }
     }

--- a/markout/src/main/kotlin/io/koalaql/markout/Markout.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/Markout.kt
@@ -18,6 +18,9 @@ import kotlin.io.path.*
 @MarkoutDsl
 interface Markout {
     @MarkoutDsl
+    fun untracked(name: String) = UntrackedName(name)
+
+    @MarkoutDsl
     fun directory(name: FileName, builder: Markout.() -> Unit)
 
     @MarkoutDsl

--- a/markout/src/main/kotlin/io/koalaql/markout/Markout.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/Markout.kt
@@ -97,6 +97,7 @@ fun metadataPaths(dir: Path, untracked: Sequence<String> = emptySequence()): Seq
     return (tracked + untracked)
         .mapNotNull { validMetadataPath(dir, it) }
         .plusElement(metadata) /* plusElement rather than plus bc Path : Iterable<Path> */
+        .distinct()
 }
 
 enum class DiffType {

--- a/markout/src/main/kotlin/io/koalaql/markout/Markout.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/Markout.kt
@@ -141,7 +141,6 @@ fun actionableFiles(output: OutputDirectory, dir: Path): ActionableFiles {
 
         metadataPaths(dir).forEach { path ->
             val entry = remaining.remove(path.name)
-
             val output = entry?.output
 
             when (output) {
@@ -175,7 +174,12 @@ fun actionableFiles(output: OutputDirectory, dir: Path): ActionableFiles {
 
         val metadataPath = dir.resolve(METADATA_FILE_NAME)
 
-        paths[metadataPath] = WriteMetadata(entries.keys)
+        paths[metadataPath] = WriteMetadata(entries
+            .asSequence()
+            .filter { it.value.tracked }
+            .map { it.key }
+            .toList()
+        )
 
         remaining.forEach { (name, entry) ->
             val path = dir.resolve(name)

--- a/markout/src/main/kotlin/io/koalaql/markout/files/WriteMetadata.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/files/WriteMetadata.kt
@@ -1,16 +1,22 @@
 package io.koalaql.markout.files
 
 import java.nio.file.Path
+import kotlin.io.path.deleteExisting
+import kotlin.io.path.deleteIfExists
 import kotlin.io.path.writeText
 
 data class WriteMetadata(
     private val keys: Collection<String>
 ): FileAction {
     override fun perform(path: Path): Nothing? {
-        path.writeText(keys.joinToString(
-            separator = "\n",
-            postfix = "\n"
-        ))
+        if (keys.isEmpty()) {
+            path.deleteIfExists()
+        } else {
+            path.writeText(keys.joinToString(
+                separator = "\n",
+                postfix = "\n"
+            ))
+        }
 
         return null
     }

--- a/markout/src/main/kotlin/io/koalaql/markout/name/FileName.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/name/FileName.kt
@@ -1,0 +1,7 @@
+package io.koalaql.markout.name
+
+sealed class FileName {
+    abstract val name: String
+
+    override fun toString(): String = name
+}

--- a/markout/src/main/kotlin/io/koalaql/markout/name/FileNames.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/name/FileNames.kt
@@ -1,0 +1,4 @@
+package io.koalaql.markout.name
+
+fun tracked(name: String) = TrackedName(name)
+fun untracked(name: String) = UntrackedName(name)

--- a/markout/src/main/kotlin/io/koalaql/markout/name/FileNames.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/name/FileNames.kt
@@ -1,4 +1,0 @@
-package io.koalaql.markout.name
-
-fun tracked(name: String) = TrackedName(name)
-fun untracked(name: String) = UntrackedName(name)

--- a/markout/src/main/kotlin/io/koalaql/markout/name/TrackedName.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/name/TrackedName.kt
@@ -1,0 +1,5 @@
+package io.koalaql.markout.name
+
+class TrackedName(
+    override val name: String
+): FileName()

--- a/markout/src/main/kotlin/io/koalaql/markout/name/UntrackedName.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/name/UntrackedName.kt
@@ -1,0 +1,5 @@
+package io.koalaql.markout.name
+
+class UntrackedName(
+    override val name: String
+): FileName()

--- a/markout/src/main/kotlin/io/koalaql/markout/output/OutputDirectory.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/output/OutputDirectory.kt
@@ -1,5 +1,5 @@
 package io.koalaql.markout.output
 
 fun interface OutputDirectory: Output {
-    fun entries(): Map<String, Output>
+    fun entries(): Map<String, OutputEntry>
 }

--- a/markout/src/main/kotlin/io/koalaql/markout/output/OutputEntry.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/output/OutputEntry.kt
@@ -1,0 +1,6 @@
+package io.koalaql.markout.output
+
+class OutputEntry(
+    val tracked: Boolean,
+    val output: Output
+)

--- a/markout/src/test/kotlin/ApplyModeTests.kt
+++ b/markout/src/test/kotlin/ApplyModeTests.kt
@@ -1,6 +1,4 @@
 import io.koalaql.markout.markout
-import io.koalaql.markout.name.UntrackedName
-import io.koalaql.markout.name.untracked
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder

--- a/markout/src/test/kotlin/ApplyModeTests.kt
+++ b/markout/src/test/kotlin/ApplyModeTests.kt
@@ -122,4 +122,35 @@ class ApplyModeTests {
             }
         }
     }
+
+    @Test
+    fun `directories are cleaned up`() {
+        val rootDir = Path(temp.root.path).apply {
+        }
+
+        markout(rootDir) {
+            directory("existing-dir") {
+                file("new-file.txt", "successfully created")
+            }
+        }
+
+        rootDir.apply {
+            assertEquals(resolve(".markout").readText(), "existing-dir\n")
+
+            resolve("existing-dir").apply {
+                assertEquals(resolve(".markout").readText(), "new-file.txt\n")
+
+                assert(isDirectory())
+                assertEquals("successfully created", resolve("new-file.txt").readText())
+            }
+        }
+
+        markout(rootDir) { }
+
+        rootDir.apply {
+            resolve("existing-dir").apply {
+                assert(notExists())
+            }
+        }
+    }
 }

--- a/markout/src/test/kotlin/ApplyModeTests.kt
+++ b/markout/src/test/kotlin/ApplyModeTests.kt
@@ -213,11 +213,13 @@ class ApplyModeTests {
 
     @Test
     fun `directories are cleaned up`() {
-        val rootDir = Path(temp.root.path).apply {
-        }
+        val rootDir = Path(temp.root.path)
 
         markout(rootDir) {
             directory("existing-dir") {
+                directory("inner-dir") {
+
+                }
                 file("new-file.txt", "successfully created")
             }
         }
@@ -226,7 +228,7 @@ class ApplyModeTests {
             assertEquals(resolve(".markout").readText(), "existing-dir\n")
 
             resolve("existing-dir").apply {
-                assertEquals(resolve(".markout").readText(), "new-file.txt\n")
+                assertEquals(resolve(".markout").readText(), "inner-dir\nnew-file.txt\n")
 
                 assert(isDirectory())
                 assertEquals("successfully created", resolve("new-file.txt").readText())
@@ -240,5 +242,42 @@ class ApplyModeTests {
                 assert(notExists())
             }
         }
+    }
+
+    @Test
+    fun `no empty dotfiles`() {
+        val rootDir = Path(temp.root.path)
+
+        markout(rootDir) {
+            directory("new-dir") { }
+        }
+
+        assert(rootDir.resolve("new-dir/.markout").notExists())
+
+        markout(rootDir) {
+            directory("new-dir") {
+                file("temp.txt", "temporarily exists")
+            }
+        }
+
+        assertEquals(
+            "new-dir\n",
+            rootDir.resolve(".markout").readText()
+        )
+
+        assertEquals(
+            "temp.txt\n",
+            rootDir.resolve("new-dir/.markout").readText()
+        )
+
+        markout(rootDir) {
+            directory("new-dir") { }
+        }
+
+        assert(rootDir.resolve("new-dir/.markout").notExists())
+
+        markout(rootDir) { }
+
+        assert(rootDir.resolve(".markout").notExists())
     }
 }

--- a/markout/src/test/kotlin/ApplyModeTests.kt
+++ b/markout/src/test/kotlin/ApplyModeTests.kt
@@ -1,5 +1,6 @@
 import io.koalaql.markout.markout
 import io.koalaql.markout.name.UntrackedName
+import io.koalaql.markout.name.untracked
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -51,7 +52,7 @@ class ApplyModeTests {
             }
 
         markout(rootDir) {
-            file(UntrackedName("untracked.txt"), "changed contents")
+            file(untracked("untracked.txt"), "changed contents")
         }
 
         assertEquals(
@@ -66,7 +67,7 @@ class ApplyModeTests {
 
         markout(rootDir) {
             file("tracked.txt", "I won't exist soon")
-            file(UntrackedName("untracked.txt"), "I will still exist")
+            file(untracked("untracked.txt"), "I will still exist")
         }
 
         assertEquals(
@@ -105,7 +106,7 @@ class ApplyModeTests {
 
         markout(rootDir) {
             file("tracked.txt", "I won't exist soon")
-            file(UntrackedName("untracked.txt"), "I will still exist")
+            file(untracked("untracked.txt"), "I will still exist")
         }
 
         assertEquals(

--- a/markout/src/test/kotlin/ApplyModeTests.kt
+++ b/markout/src/test/kotlin/ApplyModeTests.kt
@@ -69,6 +69,55 @@ class ApplyModeTests {
             file(UntrackedName("untracked.txt"), "I will still exist")
         }
 
+        assertEquals(
+            "I will still exist",
+            rootDir.resolve("untracked.txt").readText()
+        )
+
+        assertEquals(
+            "tracked.txt\n",
+            rootDir.resolve(".markout").readText()
+        )
+
+        markout(rootDir) { }
+
+        assertEquals(
+            "I will still exist",
+            rootDir.resolve("untracked.txt").readText()
+        )
+
+        assert(rootDir.resolve("tracked.txt").notExists())
+    }
+
+    @Test
+    fun `tracked files can become untracked`() {
+        val rootDir = Path(temp.root.path)
+
+        markout(rootDir) {
+            file("tracked.txt", "I won't exist soon")
+            file("untracked.txt", "I will still exist")
+        }
+
+        assertEquals(
+            "tracked.txt\nuntracked.txt\n",
+            rootDir.resolve(".markout").readText()
+        )
+
+        markout(rootDir) {
+            file("tracked.txt", "I won't exist soon")
+            file(UntrackedName("untracked.txt"), "I will still exist")
+        }
+
+        assertEquals(
+            "I will still exist",
+            rootDir.resolve("untracked.txt").readText()
+        )
+
+        assertEquals(
+            "tracked.txt\n",
+            rootDir.resolve(".markout").readText()
+        )
+
         markout(rootDir) { }
 
         assertEquals(

--- a/markout/src/test/kotlin/ApplyModeTests.kt
+++ b/markout/src/test/kotlin/ApplyModeTests.kt
@@ -61,6 +61,25 @@ class ApplyModeTests {
     }
 
     @Test
+    fun `untracked files are created but not removed`() {
+        val rootDir = Path(temp.root.path)
+
+        markout(rootDir) {
+            file("tracked.txt", "I won't exist soon")
+            file(UntrackedName("untracked.txt"), "I will still exist")
+        }
+
+        markout(rootDir) { }
+
+        assertEquals(
+            "I will still exist",
+            rootDir.resolve("untracked.txt").readText()
+        )
+
+        assert(rootDir.resolve("tracked.txt").notExists())
+    }
+
+    @Test
     fun `files created, removed and overwritten`() {
         val rootDir = Path(temp.root.path)
 

--- a/markout/test-data/untracked/.gitignore
+++ b/markout/test-data/untracked/.gitignore
@@ -1,2 +1,0 @@
-untracked.txt
-.markout

--- a/readme/src/main/kotlin/Util.kt
+++ b/readme/src/main/kotlin/Util.kt
@@ -5,6 +5,7 @@ import io.koalaql.markout.md.Markdown
 import io.koalaql.markout.md.markdown
 import io.koalaql.markout.output.Output
 import io.koalaql.markout.output.OutputDirectory
+import io.koalaql.markout.output.OutputEntry
 import io.koalaql.markout.output.OutputFile
 import io.koalaql.markout.text.AppendableLineWriter
 import io.koalaql.markout.text.LineWriter
@@ -81,18 +82,18 @@ private fun drawFileTree(
 ) {
     when (output) {
         is OutputDirectory -> {
-            val entries = (mapOf(".markout" to OutputFile { }) + output.entries())
+            val entries = (mapOf(".markout" to OutputEntry(false, OutputFile { })) + output.entries())
                 .entries
                 .toList()
 
-            entries.forEachIndexed { ix, (key, output) ->
+            entries.forEachIndexed { ix, (key, entry) ->
                 val p = if (ix < entries.size - 1) prefix.pre else prefix.post
 
                 writer.inline(p.before)
                 writer.inline(key)
                 writer.newline()
 
-                drawFileTree(PIPES_PREFIX, output, writer.prefixed(p.indent))
+                drawFileTree(PIPES_PREFIX, entry.output, writer.prefixed(p.indent))
             }
         }
         is OutputFile -> { }


### PR DESCRIPTION
Allow markout to work with untracked files which aren't listed in the `.markout` metadata file:

* Can pass `untracked(name)` to `Markout.file` and `Markout.directory`
* `untracked` files and directories won't be deleted or modified once they are no longer declared
* `untracked` files can overwrite externally generated files

As part of this change, markout will no longer generate empty `.markout` files