### PR TITLE
Expand Docs With Short Examples

### DIFF
--- a/docs/FILES.md
+++ b/docs/FILES.md
@@ -40,14 +40,11 @@ markout(Path("..")) {
 When this code is run it generates the following file tree
 
 ```
-.markout
 my-directory
-├─ .markout
 ├─ inner
-│  ├─ .markout
 │  └─ inner.txt
-├─ plain.txt
-└─ circle.svg
+├─ circle.svg
+└─ plain.txt
 readme.md
 ```
 

--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -24,14 +24,14 @@ Your generated documentation is checked into Git and used to perform
 snapshot testing on future builds.
 
 Another goal of this project is to make it easy for Kotlin developers to use the
-[Docusaurus](https://docusaurus.io/) static site generator to quickly build
+[Docusaurus][1] static site generator to quickly build
 and deploy documentation on GitHub pages. Markout can create, configure, install, build
 and run Docusaurus projects without requiring Node.js to be installed. It integrates
 with Gradle's [Continuous Build](https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continuous_build)
 to enable hot reloads and previews as you code.
 Docusaurus support is optional and provided through a separate Gradle plugin.
 
-Markout is designed to integrate with [Kapshot](https://github.com/mfwgenerics/kapshot),
+Markout is designed to integrate with [Kapshot][2],
 a minimal Kotlin compiler plugin that allows source code to be
 captured and inspected at runtime.
 Kapshot is the magic ingredient that enables fully executable and testable sample code blocks.
@@ -43,7 +43,7 @@ These file trees are reconciled into a target directory, which is your project r
 Through extra plugins and libraries, the file generation layer can be extended with functionality for
 generating markdown, capturing source code and building Docusaurus websites.
 
-### File Generation
+### File generation
 
 Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied.
 You supply a `main` method which invokes a `markout` block to describe how files should be generated.
@@ -73,4 +73,134 @@ my-project
 
 The `:markoutCheck` task then verifies that these files match subsequent runs of the code.
 
-### Extensions
+### Markdown DSL
+
+Markout is extended with a DSL for generating markdown files procedurally.
+The DSL can also be used to generate standalone Markdown strings.
+
+````mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value='main.kt' label='Main.kt'>
+
+```kotlin
+val markoutVersion = "0.0.7"
+
+markout {
+    markdown("README.md") {
+        h2("Readme")
+
+        p("Here's some *generated* Markdown with a list")
+
+        p("Using Markout version `$markoutVersion`")
+
+        ol {
+            li("One")
+            li("Two")
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem value='readme.md' label='README.md'>
+
+```markdown
+## Readme
+
+Here's some *generated* Markdown with a list
+
+Using Markout version `0.0.7`
+
+1. One
+2. Two
+```
+
+</TabItem>
+<TabItem value='rendered' label='Rendered'>
+
+> ## Readme
+> 
+> Here's some *generated* Markdown with a list
+> 
+> Using Markout version `0.0.7`
+> 
+> 1. One
+> 2. Two
+
+</TabItem>
+</Tabs>
+
+````
+
+### Source code capture
+
+Source code capture works using the [Kapshot][2] plugin.
+This allows you to execute your sample code blocks and use the results.
+
+`````mdx-code-block
+<Tabs>
+<TabItem value='main.kt' label='Main.kt'>
+
+```kotlin
+fun <T> Markdown.execCodeBlock(block: CapturedBlock<T>): T {
+    code("kotlin", block.source.text)
+
+    return block()
+}
+
+markout {
+    markdown("EXAMPLE.md") {
+        val result = execCodeBlock {
+            fun square(x: Int) = x*x
+
+            square(7)
+        }
+
+        p("The code above results in: $result")
+        p("If the result changes unexpectedly then `./gradlew check` will fail")
+    }
+}
+```
+
+</TabItem>
+<TabItem value='example.md' label='EXAMPLE.md'>
+
+````markdown
+```kotlin
+fun square(x: Int) = x*x
+
+square(7)
+```
+
+The code above results in: 49
+
+If the result changes unexpectedly then `./gradlew check` will fail
+````
+
+</TabItem>
+<TabItem value='rendered' label='Rendered'>
+
+> ```kotlin
+> fun square(x: Int) = x*x
+> 
+> square(7)
+> ```
+> 
+> The code above results in: 49
+> 
+> If the result changes unexpectedly then `./gradlew check` will fail
+
+</TabItem>
+</Tabs>
+
+`````
+
+### Docusaurus sites
+
+The Docusaurus plugin provides a `docusaurus` builder and Gradle tasks for building and running a [Docusaurus][1] site.
+
+[1]: https://docusaurus.io/
+[2]: https://github.com/mfwgenerics/kapshot

--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -38,6 +38,13 @@ Kapshot is the magic ingredient that enables fully executable and testable sampl
 
 ## How it works
 
+Markout is designed around a core file generation layer that allows file trees to be declared in code.
+These file trees are reconciled into a target directory, which is your project root directory by default.
+Through extra plugins and libraries, the file generation layer can be extended with functionality for
+generating markdown, capturing source code and building Docusaurus websites.
+
+### File Generation
+
 Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied.
 You supply a `main` method which invokes a `markout` block to describe how files should be generated.
 This code runs every time files are generated or verified.
@@ -65,3 +72,5 @@ my-project
 ```
 
 The `:markoutCheck` task then verifies that these files match subsequent runs of the code.
+
+### Extensions

--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -10,13 +10,13 @@ allows you to document Kotlin projects in code rather than text.
 Documentation written this way can be tested and verified on every build.
 Sample code becomes error proof, stays up-to-date and forms an
 extra test suite for your project. Markout can serve as an alternative
-to [kotlinx-knit](https://github.com/Kotlin/kotlinx-knit)
+to [kotlinx-knit](https://github.com/Kotlin/kotlinx-knit).
 
-## Project Purpose
+## Project purpose
 
 Documenting code is a time-consuming and error-prone process.
-Handwritten sample code is vulnerable to typos and syntax errors
-and it silently goes out of date as projects evolve.
+Not only is handwritten sample code vulnerable to typos and syntax errors,
+it silently goes out of date as projects evolve.
 Results shown in documentation are also not guaranteed to match the
 real behavior of the code. Markout seeks to address this by allowing
 your docs to execute code from your project and embed the results.
@@ -38,9 +38,9 @@ Kapshot is the magic ingredient that enables fully executable and testable sampl
 
 ## How it works
 
-Markout generates files by running code in a Kotlin project with the Markout Gradle plugin applied.
+Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied.
 You supply a `main` method which invokes a `markout` block to describe how files should be generated.
-This code runs every time files are generated or checked.
+This code runs every time files are generated or verified.
 
 ```kotlin title="Main.kt"
 fun main() = markout {
@@ -54,7 +54,7 @@ fun main() = markout {
 ```
 
 When the code above is run using `:markout`, it generates the following files
-and merges them into the project directory.
+and creates them into the project directory.
 
 ```
 my-project
@@ -64,4 +64,4 @@ my-project
    └─ OUTRO.txt
 ```
 
-The `:markoutCheck` task then verifies that these files match subsequent reruns of the code.
+The `:markoutCheck` task then verifies that these files match subsequent runs of the code.

--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -60,15 +60,15 @@ fun main() = markout {
 }
 ```
 
-When the code above is run using `:markout`, it generates the following files
-and creates them into the project directory.
+When the code above is run using `:markout`, it generates the following file tree
+and creates it in the project directory.
 
 ```
 my-project
-├─ README.txt
-└─ docs
-   ├─ INTRO.txt
-   └─ OUTRO.txt
+├─ docs
+│  ├─ INTRO.txt
+│  └─ OUTRO.txt
+└─ README.txt
 ```
 
 The `:markoutCheck` task then verifies that these files match subsequent runs of the code.
@@ -201,6 +201,51 @@ If the result changes unexpectedly then `./gradlew check` will fail
 ### Docusaurus sites
 
 The Docusaurus plugin provides a `docusaurus` builder and Gradle tasks for building and running a [Docusaurus][1] site.
+
+````mdx-code-block
+<Tabs>
+<TabItem value='main.kt' label='Main.kt'>
+
+```kotlin
+markout {
+    docusaurus("my-site") {
+        configure {
+            title = "Example Site"
+        }
+
+        docs {
+            markdown("hello.md") {
+                h1("Hello Docusaurus!")
+            }
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem value='generated files' label='Generated Files'>
+
+```
+my-project
+└─ my-site
+   ├─ docs
+   │  └─ hello.md
+   ├─ static
+   │  └─ .nojekyll
+   ├─ .gitignore
+   ├─ babel.config.js
+   ├─ docusaurus.config.js
+   ├─ linux.yarnrc
+   ├─ package.json
+   ├─ sidebars.js
+   ├─ tsconfig.json
+   └─ yarn.lock
+```
+
+</TabItem>
+</Tabs>
+
+````
 
 [1]: https://docusaurus.io/
 [2]: https://github.com/mfwgenerics/kapshot

--- a/markout-docusaurus/src/main/kotlin/io/koalaql/markout/docusaurus/Docusauruses.kt
+++ b/markout-docusaurus/src/main/kotlin/io/koalaql/markout/docusaurus/Docusauruses.kt
@@ -104,6 +104,8 @@ fun Markout.docusaurus(block: DocusaurusRoot.() -> Unit) {
                 }
             }
 
+            copyResource("/bootstrap/gitignore", ".gitignore")
+
             this@docusaurus.file(this@docusaurus.untracked("docusaurus.config.js")) {
                 val writer = it.writer()
 
@@ -115,7 +117,6 @@ fun Markout.docusaurus(block: DocusaurusRoot.() -> Unit) {
                 writer.flush()
             }
 
-            copyResource("/bootstrap/gitignore", ".gitignore")
             copyResource("/bootstrap/babel.config.js")
             copyResource("/bootstrap/package.json")
             copyResource("/bootstrap/sidebars.js")
@@ -157,3 +158,9 @@ fun Markout.docusaurus(block: DocusaurusRoot.() -> Unit) {
         }
     }.block()
 }
+
+@MarkoutDsl
+fun Markout.docusaurus(name: String, block: DocusaurusRoot.() -> Unit) =
+    directory(name) {
+        docusaurus(block)
+    }

--- a/markout-docusaurus/src/main/kotlin/io/koalaql/markout/docusaurus/Docusauruses.kt
+++ b/markout-docusaurus/src/main/kotlin/io/koalaql/markout/docusaurus/Docusauruses.kt
@@ -104,8 +104,6 @@ fun Markout.docusaurus(block: DocusaurusRoot.() -> Unit) {
                 }
             }
 
-            copyResource("/bootstrap/gitignore", ".gitignore")
-
             this@docusaurus.file(this@docusaurus.untracked("docusaurus.config.js")) {
                 val writer = it.writer()
 
@@ -117,6 +115,7 @@ fun Markout.docusaurus(block: DocusaurusRoot.() -> Unit) {
                 writer.flush()
             }
 
+            copyResource("/bootstrap/gitignore", ".gitignore")
             copyResource("/bootstrap/babel.config.js")
             copyResource("/bootstrap/package.json")
             copyResource("/bootstrap/sidebars.js")

--- a/markout/src/main/kotlin/io/koalaql/markout/text/LineWriter.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/text/LineWriter.kt
@@ -21,6 +21,8 @@ interface LineWriter {
         newline()
     }
 
+    fun line() = newline()
+
     fun raw(text: String) {
         if (text.isEmpty()) return
 

--- a/readme/src/main/kotlin/Util.kt
+++ b/readme/src/main/kotlin/Util.kt
@@ -78,16 +78,16 @@ private val PIPES_PREFIX = Prefix(
 private fun drawFileTree(
     prefix: Prefix,
     output: Output,
-    writer: LineWriter,
-    dotfiles: Boolean = true
+    writer: LineWriter
 ) {
     when (output) {
         is OutputDirectory -> {
-            val entries = if (dotfiles) {
-                (mapOf(".markout" to OutputEntry(false, OutputFile { })) + output.entries())
-            } else {
-                output.entries()
-            }.toList()
+            val entries = output.entries()
+                .asSequence()
+                .sortedBy {
+                    "${it.value.output !is OutputDirectory}-${it.key}"
+                }
+                .toList()
 
             entries.forEachIndexed { ix, (key, entry) ->
                 val p = if (ix < entries.size - 1) prefix.pre else prefix.post
@@ -96,12 +96,12 @@ private fun drawFileTree(
                 writer.inline(key)
                 writer.newline()
 
-                drawFileTree(PIPES_PREFIX, entry.output, writer.prefixed(p.indent), dotfiles)
+                drawFileTree(PIPES_PREFIX, entry.output, writer.prefixed(p.indent))
             }
         }
         is OutputFile -> { }
     }
 }
 
-fun drawFileTree(output: Output, dotfiles: Boolean = true): String =
-    "${StringBuilder().also { drawFileTree(NO_PREFIX, output, AppendableLineWriter(it).trimmedLines(), dotfiles) }}"
+fun drawFileTree(output: Output): String =
+    "${StringBuilder().also { drawFileTree(NO_PREFIX, output, AppendableLineWriter(it).trimmedLines()) }}"

--- a/readme/src/main/kotlin/docusaurus/Docusaurus.kt
+++ b/readme/src/main/kotlin/docusaurus/Docusaurus.kt
@@ -72,6 +72,13 @@ fun Markout.setupDocusaurus() = docusaurus {
 
             h2("How it works")
 
+            -"Markout is designed around a core file generation layer that allows file trees to be declared in code."
+            -"These file trees are reconciled into a target directory, which is your project root directory by default."
+            -"Through extra plugins and libraries, the file generation layer can be extended with functionality for"
+            -"generating markdown, capturing source code and building Docusaurus websites."
+
+            h3("File Generation")
+
             -"Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied."
             -"You supply a `main` method which invokes a `markout` block to describe how files should be generated."
             -"This code runs every time files are generated or verified."
@@ -107,6 +114,8 @@ fun Markout.setupDocusaurus() = docusaurus {
             code(fileTree)
 
             -"The `:markoutCheck` task then verifies that these files match subsequent runs of the code."
+
+            h3("Extensions")
         }
     }
 }

--- a/readme/src/main/kotlin/docusaurus/Docusaurus.kt
+++ b/readme/src/main/kotlin/docusaurus/Docusaurus.kt
@@ -1,13 +1,7 @@
 package docusaurus
 
-import drawFileTree
-import io.koalaql.kapshot.CapturedBlock
 import io.koalaql.markout.Markout
-import io.koalaql.markout.buildOutput
 import io.koalaql.markout.docusaurus.docusaurus
-import io.koalaql.markout.md.markdown
-import io.koalaql.markout.output.OutputDirectory
-import io.koalaql.markout.output.OutputEntry
 
 fun Markout.setupDocusaurus() = docusaurus {
     configure {
@@ -22,100 +16,6 @@ fun Markout.setupDocusaurus() = docusaurus {
     }
 
     docs {
-        markdown("intro") {
-            slug = "/"
-
-            h1("Introduction")
-
-            p {
-                -"Markout is an executable documentation platform for Kotlin that"
-                -"allows you to document Kotlin projects in code rather than text."
-                -"Documentation written this way can be tested and verified on every build."
-                -"Sample code becomes error proof, stays up-to-date and forms an"
-                -"extra test suite for your project. Markout can serve as an alternative"
-                -"to "+a("https://github.com/Kotlin/kotlinx-knit", "kotlinx-knit")+"."
-            }
-
-            h2("Project purpose")
-
-            p {
-                -"Documenting code is a time-consuming and error-prone process."
-                -"Not only is handwritten sample code vulnerable to typos and syntax errors,"
-                -"it silently goes out of date as projects evolve."
-                -"Results shown in documentation are also not guaranteed to match the"
-                -"real behavior of the code. Markout seeks to address this by allowing"
-                -"your docs to execute code from your project and embed the results."
-                -"Your generated documentation is checked into Git and used to perform"
-                -"snapshot testing on future builds."
-            }
-
-            p {
-                -"Another goal of this project is to make it easy for Kotlin developers to use the"
-                -" "+a("https://docusaurus.io/", "Docusaurus")+" static site generator to quickly build"
-                -"and deploy documentation on GitHub pages. Markout can create, configure, install, build"
-                -"and run Docusaurus projects without requiring Node.js to be installed. It integrates"
-                -"with Gradle's "
-                a(
-                    "https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continuous_build",
-                    "Continuous Build"
-                )
-                -"to enable hot reloads and previews as you code."
-                -"Docusaurus support is optional and provided through a separate Gradle plugin."
-            }
-
-            p {
-                -"Markout is designed to integrate with "+a("https://github.com/mfwgenerics/kapshot", "Kapshot")+","
-                -"a minimal Kotlin compiler plugin that allows source code to be"
-                -"captured and inspected at runtime."
-                -"Kapshot is the magic ingredient that enables fully executable and testable sample code blocks."
-            }
-
-            h2("How it works")
-
-            -"Markout is designed around a core file generation layer that allows file trees to be declared in code."
-            -"These file trees are reconciled into a target directory, which is your project root directory by default."
-            -"Through extra plugins and libraries, the file generation layer can be extended with functionality for"
-            -"generating markdown, capturing source code and building Docusaurus websites."
-
-            h3("File Generation")
-
-            -"Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied."
-            -"You supply a `main` method which invokes a `markout` block to describe how files should be generated."
-            -"This code runs every time files are generated or verified."
-
-            var fileTree: String = ""
-
-            fun markout(builder: Markout.() -> Unit) {
-                fileTree = drawFileTree(object : OutputDirectory {
-                    override fun entries(): Map<String, OutputEntry> = mapOf("my-project" to OutputEntry(
-                        tracked = false,
-                        buildOutput(builder)
-                    ))
-                }, dotfiles = false)
-            }
-
-            fun execBlock(block: CapturedBlock<Unit>): String =
-                block.source.text.also { block.invoke() }
-
-            code("kotlin", "Main.kt", "fun main() = ${execBlock {
-                markout {
-                    file("README.txt", "Hello world!")
-
-                    directory("docs") {
-                        file("INTRO.txt", "Another text file!")
-                        file("OUTRO.txt", "A final text file")
-                    }
-                }
-            }}")
-
-            -"When the code above is run using `:markout`, it generates the following files"
-            -"and creates them into the project directory."
-
-            code(fileTree)
-
-            -"The `:markoutCheck` task then verifies that these files match subsequent runs of the code."
-
-            h3("Extensions")
-        }
+        intro()
     }
 }

--- a/readme/src/main/kotlin/docusaurus/Docusaurus.kt
+++ b/readme/src/main/kotlin/docusaurus/Docusaurus.kt
@@ -33,15 +33,15 @@ fun Markout.setupDocusaurus() = docusaurus {
                 -"Documentation written this way can be tested and verified on every build."
                 -"Sample code becomes error proof, stays up-to-date and forms an"
                 -"extra test suite for your project. Markout can serve as an alternative"
-                -"to "+a("https://github.com/Kotlin/kotlinx-knit", "kotlinx-knit")
+                -"to "+a("https://github.com/Kotlin/kotlinx-knit", "kotlinx-knit")+"."
             }
 
-            h2("Project Purpose")
+            h2("Project purpose")
 
             p {
                 -"Documenting code is a time-consuming and error-prone process."
-                -"Handwritten sample code is vulnerable to typos and syntax errors"
-                -"and it silently goes out of date as projects evolve."
+                -"Not only is handwritten sample code vulnerable to typos and syntax errors,"
+                -"it silently goes out of date as projects evolve."
                 -"Results shown in documentation are also not guaranteed to match the"
                 -"real behavior of the code. Markout seeks to address this by allowing"
                 -"your docs to execute code from your project and embed the results."
@@ -72,9 +72,9 @@ fun Markout.setupDocusaurus() = docusaurus {
 
             h2("How it works")
 
-            -"Markout generates files by running code in a Kotlin project with the Markout Gradle plugin applied."
+            -"Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied."
             -"You supply a `main` method which invokes a `markout` block to describe how files should be generated."
-            -"This code runs every time files are generated or checked."
+            -"This code runs every time files are generated or verified."
 
             var fileTree: String = ""
 
@@ -102,11 +102,11 @@ fun Markout.setupDocusaurus() = docusaurus {
             }}")
 
             -"When the code above is run using `:markout`, it generates the following files"
-            -"and merges them into the project directory."
+            -"and creates them into the project directory."
 
             code(fileTree)
 
-            -"The `:markoutCheck` task then verifies that these files match subsequent reruns of the code."
+            -"The `:markoutCheck` task then verifies that these files match subsequent runs of the code."
         }
     }
 }

--- a/readme/src/main/kotlin/docusaurus/Intro.kt
+++ b/readme/src/main/kotlin/docusaurus/Intro.kt
@@ -1,0 +1,227 @@
+package docusaurus
+
+import MARKOUT_VERSION
+import drawFileTree
+import io.koalaql.kapshot.CapturedBlock
+import io.koalaql.markout.Markout
+import io.koalaql.markout.buildOutput
+import io.koalaql.markout.docusaurus.Docusaurus
+import io.koalaql.markout.docusaurus.DocusaurusMarkdown
+import io.koalaql.markout.md.Markdown
+import io.koalaql.markout.md.markdown
+import io.koalaql.markout.output.OutputDirectory
+import io.koalaql.markout.output.OutputEntry
+import io.koalaql.markout.output.OutputFile
+import java.io.ByteArrayOutputStream
+
+
+private fun DocusaurusMarkdown.markdownDslExample() {
+    lateinit var markoutOutput: Pair<String, String>
+
+    fun markout(builder: Markout.() -> Unit) {
+        markoutOutput = buildOutput(builder).entries().mapValues { entry ->
+            with (entry.value.output as OutputFile) {
+                ByteArrayOutputStream()
+                    .also { writeTo(it) }
+                    .toByteArray()
+                    .toString(Charsets.UTF_8)
+                    .trim()
+            }
+        }.entries.map { (x,y) -> x to y }.first()
+    }
+
+    val markoutVersion = MARKOUT_VERSION
+
+    val source = execBlock {
+        markout {
+            markdown("README.md") {
+                h2("Readme")
+
+                p("Here's some *generated* Markdown with a list")
+
+                p("Using Markout version `$markoutVersion`")
+
+                ol {
+                    li("One")
+                    li("Two")
+                }
+            }
+        }
+    }
+
+    tabbed(imports = true, mapOf(
+        "Main.kt" to {
+            code("kotlin", "val markoutVersion = \"$MARKOUT_VERSION\"\n\n${source}")
+        },
+        markoutOutput.first to {
+            code("markdown", markoutOutput.second)
+        },
+        "Rendered" to {
+            quote {
+                raw(markoutOutput.second)
+            }
+        }
+    ))
+}
+
+private fun DocusaurusMarkdown.sourceCaptureExample() {
+    lateinit var markoutOutput: Pair<String, String>
+
+    fun markout(builder: Markout.() -> Unit) {
+        markoutOutput = buildOutput(builder).entries().mapValues { entry ->
+            with (entry.value.output as OutputFile) {
+                ByteArrayOutputStream()
+                    .also { writeTo(it) }
+                    .toByteArray()
+                    .toString(Charsets.UTF_8)
+                    .trim()
+            }
+        }.entries.map { (x,y) -> x to y }.first()
+    }
+
+    val source = execBlock {
+        fun <T> Markdown.execCodeBlock(block: CapturedBlock<T>): T {
+            code("kotlin", block.source.text)
+
+            return block()
+        }
+
+        markout {
+            markdown("EXAMPLE.md") {
+                val result = execCodeBlock {
+                    fun square(x: Int) = x*x
+
+                    square(7)
+                }
+
+                p("The code above results in: $result")
+                p("If the result changes unexpectedly then `./gradlew check` will fail")
+            }
+        }
+    }
+
+    tabbed(imports = false, mapOf(
+        "Main.kt" to {
+            code("kotlin", source)
+        },
+        markoutOutput.first to {
+            code("markdown", markoutOutput.second)
+        },
+        "Rendered" to {
+            quote {
+                raw(markoutOutput.second)
+            }
+        }
+    ))
+}
+
+fun Docusaurus.intro() = markdown("intro") {
+    slug = "/"
+
+    h1("Introduction")
+
+    p {
+        -"Markout is an executable documentation platform for Kotlin that"
+        -"allows you to document Kotlin projects in code rather than text."
+        -"Documentation written this way can be tested and verified on every build."
+        -"Sample code becomes error proof, stays up-to-date and forms an"
+        -"extra test suite for your project. Markout can serve as an alternative"
+        -"to "+a("https://github.com/Kotlin/kotlinx-knit", "kotlinx-knit")+"."
+    }
+
+    h2("Project purpose")
+
+    p {
+        -"Documenting code is a time-consuming and error-prone process."
+        -"Not only is handwritten sample code vulnerable to typos and syntax errors,"
+        -"it silently goes out of date as projects evolve."
+        -"Results shown in documentation are also not guaranteed to match the"
+        -"real behavior of the code. Markout seeks to address this by allowing"
+        -"your docs to execute code from your project and embed the results."
+        -"Your generated documentation is checked into Git and used to perform"
+        -"snapshot testing on future builds."
+    }
+
+    p {
+        -"Another goal of this project is to make it easy for Kotlin developers to use the"
+        -" "+a(cite("https://docusaurus.io/"), "Docusaurus")+" static site generator to quickly build"
+        -"and deploy documentation on GitHub pages. Markout can create, configure, install, build"
+        -"and run Docusaurus projects without requiring Node.js to be installed. It integrates"
+        -"with Gradle's "
+        a(
+            "https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continuous_build",
+            "Continuous Build"
+        )
+        -"to enable hot reloads and previews as you code."
+        -"Docusaurus support is optional and provided through a separate Gradle plugin."
+    }
+
+    p {
+        -"Markout is designed to integrate with "+a(cite("https://github.com/mfwgenerics/kapshot"), "Kapshot")+","
+        -"a minimal Kotlin compiler plugin that allows source code to be"
+        -"captured and inspected at runtime."
+        -"Kapshot is the magic ingredient that enables fully executable and testable sample code blocks."
+    }
+
+    h2("How it works")
+
+    -"Markout is designed around a core file generation layer that allows file trees to be declared in code."
+    -"These file trees are reconciled into a target directory, which is your project root directory by default."
+    -"Through extra plugins and libraries, the file generation layer can be extended with functionality for"
+    -"generating markdown, capturing source code and building Docusaurus websites."
+
+    h3("File generation")
+
+    -"Markout generates files by running code from Kotlin projects with the Markout Gradle plugin applied."
+    -"You supply a `main` method which invokes a `markout` block to describe how files should be generated."
+    -"This code runs every time files are generated or verified."
+
+    lateinit var markoutOutput: OutputDirectory
+
+    fun markout(builder: Markout.() -> Unit) {
+        markoutOutput = buildOutput(builder)
+    }
+
+    code("kotlin", "Main.kt", "fun main() = ${execBlock {
+        markout {
+            file("README.txt", "Hello world!")
+
+            directory("docs") {
+                file("INTRO.txt", "Another text file!")
+                file("OUTRO.txt", "A final text file")
+            }
+        }
+    }}")
+
+    -"When the code above is run using `:markout`, it generates the following files"
+    -"and creates them into the project directory."
+
+    code(drawFileTree(object : OutputDirectory {
+        override fun entries(): Map<String, OutputEntry> = mapOf("my-project" to OutputEntry(
+            tracked = false,
+            markoutOutput
+        )
+        )
+    }, dotfiles = false))
+
+    -"The `:markoutCheck` task then verifies that these files match subsequent runs of the code."
+
+    h3("Markdown DSL")
+
+    -"Markout is extended with a DSL for generating markdown files procedurally."
+    -"The DSL can also be used to generate standalone Markdown strings."
+
+    markdownDslExample()
+
+    h3("Source code capture")
+
+    -"Source code capture works using the "+a(cite("https://github.com/mfwgenerics/kapshot"), "Kapshot")+" plugin."
+    -"This allows you to execute your sample code blocks and use the results."
+
+    sourceCaptureExample()
+
+    h3("Docusaurus sites")
+
+    -"The Docusaurus plugin provides a `docusaurus` builder and Gradle tasks for building and running a "
+    a(cite("https://docusaurus.io/"), "Docusaurus")+" site."
+}

--- a/readme/src/main/kotlin/docusaurus/Intro.kt
+++ b/readme/src/main/kotlin/docusaurus/Intro.kt
@@ -7,13 +7,21 @@ import io.koalaql.markout.Markout
 import io.koalaql.markout.buildOutput
 import io.koalaql.markout.docusaurus.Docusaurus
 import io.koalaql.markout.docusaurus.DocusaurusMarkdown
+import io.koalaql.markout.docusaurus.docusaurus
 import io.koalaql.markout.md.Markdown
 import io.koalaql.markout.md.markdown
+import io.koalaql.markout.output.Output
 import io.koalaql.markout.output.OutputDirectory
 import io.koalaql.markout.output.OutputEntry
 import io.koalaql.markout.output.OutputFile
 import java.io.ByteArrayOutputStream
 
+private fun drawProjectFileTree(output: Output) = drawFileTree(object : OutputDirectory {
+    override fun entries(): Map<String, OutputEntry> = mapOf("my-project" to OutputEntry(
+        tracked = false,
+        output
+    ))
+})
 
 private fun DocusaurusMarkdown.markdownDslExample() {
     lateinit var markoutOutput: Pair<String, String>
@@ -115,6 +123,39 @@ private fun DocusaurusMarkdown.sourceCaptureExample() {
     ))
 }
 
+private fun DocusaurusMarkdown.docusaurusExample() {
+    lateinit var fileTree: String
+
+    fun markout(builder: Markout.() -> Unit) {
+        fileTree = drawProjectFileTree(buildOutput(builder))
+    }
+
+    val source = execBlock {
+        markout {
+            docusaurus("my-site") {
+                configure {
+                    title = "Example Site"
+                }
+
+                docs {
+                    markdown("hello.md") {
+                        h1("Hello Docusaurus!")
+                    }
+                }
+            }
+        }
+    }
+
+    tabbed(imports = false, mapOf(
+        "Main.kt" to {
+            code("kotlin", source)
+        },
+        "Generated Files" to {
+            code(fileTree)
+        }
+    ))
+}
+
 fun Docusaurus.intro() = markdown("intro") {
     slug = "/"
 
@@ -193,16 +234,10 @@ fun Docusaurus.intro() = markdown("intro") {
         }
     }}")
 
-    -"When the code above is run using `:markout`, it generates the following files"
-    -"and creates them into the project directory."
+    -"When the code above is run using `:markout`, it generates the following file tree"
+    -"and creates it in the project directory."
 
-    code(drawFileTree(object : OutputDirectory {
-        override fun entries(): Map<String, OutputEntry> = mapOf("my-project" to OutputEntry(
-            tracked = false,
-            markoutOutput
-        )
-        )
-    }, dotfiles = false))
+    code(drawProjectFileTree(markoutOutput))
 
     -"The `:markoutCheck` task then verifies that these files match subsequent runs of the code."
 
@@ -224,4 +259,6 @@ fun Docusaurus.intro() = markdown("intro") {
 
     -"The Docusaurus plugin provides a `docusaurus` builder and Gradle tasks for building and running a "
     a(cite("https://docusaurus.io/"), "Docusaurus")+" site."
+
+    docusaurusExample()
 }

--- a/readme/src/main/kotlin/docusaurus/Util.kt
+++ b/readme/src/main/kotlin/docusaurus/Util.kt
@@ -1,0 +1,38 @@
+package docusaurus
+
+import io.koalaql.kapshot.CapturedBlock
+import io.koalaql.markout.docusaurus.DocusaurusMarkdown
+import io.koalaql.markout.md.Markdown
+import io.koalaql.markout.md.markdown
+import io.koalaql.markout.text.AppendableLineWriter
+
+fun execBlock(block: CapturedBlock<Unit>): String =
+    block.source.text.also { block.invoke() }
+
+fun DocusaurusMarkdown.tabbed(
+    imports: Boolean,
+    tabs: Map<String, Markdown.() -> Unit>
+) {
+    val builder = StringBuilder()
+
+    AppendableLineWriter(builder).apply {
+        if (imports) {
+            line("import Tabs from '@theme/Tabs';")
+            line("import TabItem from '@theme/TabItem';")
+            line()
+        }
+
+        line("<Tabs>")
+        tabs.forEach { (k, v) ->
+            line("<TabItem value='${k.lowercase()}' label='${k}'>")
+            line()
+            raw(markdown(v))
+            line()
+            line()
+            line("</TabItem>")
+        }
+        line("</Tabs>")
+    }
+
+    code("mdx-code-block", "$builder")
+}


### PR DESCRIPTION
"How it works" section is now split into short examples of capabilities. These will eventually be populated with links to more in-depth documentation on each capability.