### PR TITLE
Docusaurus Working Directories

### DIFF
--- a/markout-docusaurus-plugin/build.gradle.kts
+++ b/markout-docusaurus-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation("com.github.node-gradle:gradle-node-plugin:3.5.1")
     implementation("io.koalaql:kapshot-plugin-gradle:0.1.1")
-    implementation("io.koalaql:markout-plugin")
+    implementation("io.koalaql:markout-plugin:${project.version}")
 }
 
 pluginBundle {

--- a/markout-plugin/src/main/kotlin/io/koalaql/markout/GradlePlugin.kt
+++ b/markout-plugin/src/main/kotlin/io/koalaql/markout/GradlePlugin.kt
@@ -7,6 +7,12 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.JavaExec
 import java.util.concurrent.Callable
 import io.koalaql.markout_plugin.BuildConfig
+import org.gradle.api.tasks.OutputFile
+
+open class MarkoutExecTask: JavaExec() {
+    @OutputFile
+    val outputPath = project.buildDir.toPath().resolve("markout/paths.txt")
+}
 
 class GradlePlugin: Plugin<Project> {
     override fun apply(target: Project) = with(target) {
@@ -24,9 +30,23 @@ class GradlePlugin: Plugin<Project> {
             }
         }
 
-        fun execTask(name: String, builder: (JavaExec) -> Unit) = tasks
-            .register(name, JavaExec::class.java) {
+        fun execTask(name: String, builder: (MarkoutExecTask) -> Unit) = tasks
+            .register(name, MarkoutExecTask::class.java) {
                 val ext = target.extensions.getByType(MarkoutConfig::class.java)
+
+                val markoutBuildDir = project
+                    .buildDir
+                    .toPath()
+                    .resolve("markout")
+
+                it.doFirst {
+                    markoutBuildDir.toFile().apply {
+                        deleteRecursively()
+                        mkdir()
+                    }
+                }
+
+                it.environment("MARKOUT_BUILD_DIR", "$markoutBuildDir")
 
                 it.group = "markout"
 

--- a/markout/src/main/kotlin/io/koalaql/markout/ActionableFiles.kt
+++ b/markout/src/main/kotlin/io/koalaql/markout/ActionableFiles.kt
@@ -10,6 +10,9 @@ class ActionableFiles(
         return paths.mapNotNull { (path, action) -> action.perform(path) }
     }
 
+    fun paths(): List<Path> =
+        paths.asSequence().map { it.key }.toList()
+
     fun expect(): List<Diff> {
         val visited = linkedMapOf<Path, Boolean>()
 


### PR DESCRIPTION
* Markout tasks produce `paths.txt` as a build output
* Docusaurus plugin auto-configures working directory from `paths.txt`
* Force use of `--continuous` mode with `:docusaurusStart`
* Fix unoptimizable lambda usage in Markout Gradle task config
* Fix missing version number for `markout-plugin` dependency in `markout-docusaurus-plugin`
